### PR TITLE
fix: removing purr_oplog as it is not necessary anymore

### DIFF
--- a/etl/extract/transfer_info.py
+++ b/etl/extract/transfer_info.py
@@ -4,13 +4,6 @@ from etl.load import table, row
 from etl.monitor import logger
 
 table_desc = {
-    "purr_oplog": {
-        "attrs": ["id", "operation", "relation", "obj_id",
-                  "ts", "merged", "document"],
-        "types": ["SERIAL", "TEXT", "TEXT", "TEXT",
-                  "INTEGER", "BOOLEAN", "TEXT"],
-        "pks": ["id", "ts"]
-    },
     "purr_info": {
         "attrs": ["id", "relation", "latest_successful_ts"],
         "types": ["INTEGER", "TEXT", "TEXT"]
@@ -30,7 +23,6 @@ table_desc = {
 
 def save_logs_to_db(db, schema='public'):
     create_stat_table(db, schema)
-    create_oplog_table(db, schema)
     create_transfer_stats_table(db, schema)
     create_log_error_table(db, schema)
 
@@ -107,66 +99,6 @@ def update_latest_successful_ts(db, schema, dt):
             of the latest successful transfer: %s"""
             % (ex)
         )
-
-
-def create_oplog_table(db, schema='public'):
-    """
-    Logs the operation, relation name, object id and
-    timestamp for each entry of the oplog.
-
-    Parameters
-    ----------
-    db: connection obj
-    schema: name of the schema in Postgres
-    Returns
-    -------
-    -
-
-    Example
-    -------
-    create_oplog_table(pg, 'purr')
-
-    """
-    table_name = "purr_oplog"
-    attrs = table_desc[table_name]["attrs"]
-    types = table_desc[table_name]["types"]
-    pks = table_desc[table_name]["pks"]
-
-    try:
-        table.drop(db, schema, [table_name])
-        table.create(db, schema, table_name, attrs, types, pks)
-        logger.info("[TRANSFER INFO] Created table %s." % (table_name))
-    except Exception as ex:
-        logger.error(
-            "[TRANSFER_INFO] Failed to create table %s: %s" % (table_name, ex))
-
-
-def log_rows(db, schema, values):
-    """
-    Holds the operation, relation name, object id and
-    timestamp for each entry of the oplog.
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-    -
-
-    Example
-    -------
-    create_oplog_table(pg, 'purr')
-
-    """
-    table_name = "purr_oplog"
-    # id is SERIAL type, we can skip it when inserting rows:
-    attrs = table_desc[table_name]["attrs"][1:]
-    try:
-        row.insert_bulk(db, schema, table_name, attrs, values)
-    except Exception as ex:
-        logger.error(
-            "[TRANSFER_INFO] Failed to insert logs into table %s: %s"
-            % (table_name, ex))
 
 
 def create_transfer_stats_table(db, schema='public'):

--- a/tests/extract/test_tailer.py
+++ b/tests/extract/test_tailer.py
@@ -189,7 +189,6 @@ class TestTailer(unittest.TestCase):
         assert mocked == docs_useful and merged is True
 
     def test_handle_multiple(self):
-        transfer_info.create_oplog_table(pg, 'public')
         reset_dataset()
         oplog_entries = mock.oplog_entries_update
         create_and_populate_company_pg()
@@ -248,73 +247,3 @@ class TestTailer(unittest.TestCase):
 
         assert True
 
-    def test_log_tailed_docs_one(self):
-        transfer_info.create_oplog_table(pg)
-
-        ids_log = ['58a32cfda51183070034909b']
-        docs = [{
-            '_id': '58a32cfda51183070034909b',
-            'updatedAt': datetime.datetime(2019, 4, 29, 11, 26, 50, 703000)
-        }]
-        table_name = 'some_relation'
-        oper = 'u'
-        merged = True
-        cursor = pg.conn.cursor()
-        schema = 'public'
-        tailer.log_tailed_docs(pg, schema, docs,
-                               ids_log, table_name, oper,
-                               merged)
-        cursor.execute(
-            """SELECT operation,
-            relation, obj_id, merged, document FROM purr_oplog;""")
-        res = cursor.fetchone()
-        cursor.close()
-        mock = tuple(
-            ['u',
-             'some_relation',
-             '58a32cfda51183070034909b',
-             True,
-             "{'_id': '58a32cfda51183070034909b', 'updatedAt': datetime.datetime(2019, 4, 29, 11, 26, 50, 703000)}"
-             ])
-        assert mock == res
-
-    def test_log_tailed_docs_multiple(self):
-        transfer_info.create_oplog_table(pg)
-
-        ids_log = ['58a32cfda51183070034909b', '58a32cfda51183070034909c']
-        docs = [{
-            '_id': '58a32cfda51183070034909b',
-            'updatedAt': datetime.datetime(2019, 4, 29, 11, 26, 50, 703000)
-        }, {
-            '_id': '58a32cfda51183070034909c',
-            'updatedAt': datetime.datetime(2019, 5, 21, 2, 24, 24, 5)
-        }]
-        table_name = 'some_relation'
-        oper = 'u'
-        merged = False
-        cursor = pg.conn.cursor()
-        schema = 'public'
-        tailer.log_tailed_docs(pg, schema, docs,
-                               ids_log, table_name, oper,
-                               merged)
-        cursor.execute(
-            """SELECT operation,
-            relation, obj_id, merged, document FROM purr_oplog order by id;""")
-        res = cursor.fetchall()
-        mock = [
-            tuple(
-                ['u',
-                 'some_relation',
-                 '58a32cfda51183070034909b',
-                 False,
-                 "{'_id': '58a32cfda51183070034909b', 'updatedAt': datetime.datetime(2019, 4, 29, 11, 26, 50, 703000)}"
-                 ]),
-            tuple(
-                ['u',
-                 'some_relation',
-                 '58a32cfda51183070034909c',
-                 False,
-                 "{'_id': '58a32cfda51183070034909c', 'updatedAt': datetime.datetime(2019, 5, 21, 2, 24, 24, 5)}"
-                 ])]
-        cursor.close()
-        assert mock == res

--- a/tests/extract/test_transfer_info.py
+++ b/tests/extract/test_transfer_info.py
@@ -10,11 +10,3 @@ def test_get_latest_successful_ts():
 
 def test_update_latest_successful_ts():
     pass
-
-
-def test_create_oplog_table():
-    pass
-
-
-def test_log_rows():
-    pass


### PR DESCRIPTION
- slows down the data transfer when tailing
- was used to figure out which documents were partially updated